### PR TITLE
Add Commitment Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 
 ## 📢 Explore the Directory  
 
+- [Commitment Issues](https://github.com/dotsystemsdevs/commitmentissues) - Free open-source web app that issues a satirical "death certificate" for abandoned GitHub repos — algorithmic cause of death, last commit as last words, severity score, profile graveyard scan.
+
 ### 🔗 [Communities](./Communities.md)  
 
 Find the best places to share, promote, and discuss your startup.  


### PR DESCRIPTION
Adding **Commitment Issues** to this list.

### What it does
Free open-source web app that issues a satirical "death certificate" for abandoned GitHub repos — algorithmic cause of death, last commit as last words, severity score, profile graveyard scan.

### Why it fits
- Free, open source (MIT), no signup, no ads
- Useful for developers vetting dependencies or cleaning up bookmarks
- Live at https://commitmentissues.dev, source at https://github.com/dotsystemsdevs/commitmentissues

Thanks for maintaining this list 🦥