### PR TITLE
Add Tura to Product Development tools

### DIFF
--- a/FounderTools.md
+++ b/FounderTools.md
@@ -27,6 +27,7 @@ This directory is part of the **[Awesome Launch](./README.md)** project, a crowd
 Tools to help you develop a product or service.
 
 - [GitHub](https://github.com/) – Code hosting, collaboration, and version control.  
+- [Tura](https://github.com/Tura-AI/tura) – Open-source local coding agent with terminal, TUI, and desktop interfaces, custom model providers, and cross-platform support.
 - [GitLab](https://gitlab.com/) – Alternative to GitHub with CI/CD built-in.  
 - [Bitbucket](https://bitbucket.org/) – Git repository for teams, integrated with Jira.  
 - [Supabase](https://supabase.com/) – Open-source Firebase alternative for backend services.  


### PR DESCRIPTION
## Summary

Add Tura to `FounderTools.md` under **Product Development**. Tura is an open-source local coding agent with terminal, TUI, and desktop interfaces, custom model providers, and cross-platform support.

## Why it fits

The section is for tools that help founders and indie developers build products; Tura helps inspect, edit, and verify product code.

## Checks

- confirmed there is no existing Tura entry, pull request, or issue
- changed one list entry only
- previewed the rendered Markdown

**Disclosure:** I am a maintainer of Tura.