### PR TITLE
Add Mydentify to product and startup directories

### DIFF
--- a/Communities.md
+++ b/Communities.md
@@ -82,6 +82,7 @@ Sites that list startups for long-term visibility.
 - **[AngelList](https://angel.co/)** – Startup database for fundraising and talent.
 - **[Capterra](https://www.capterra.com/)** – Review platform for software businesses.
 - **[GetApp](https://www.getapp.com/)** – Business software directory.
+- **[Mydentify](https://mydentify.com/)** – Permanent product directory organized by user goals, with free listings and weekly leaderboards.
 - **[SaaSworthy](https://www.saasworthy.com/)** – SaaS comparison and reviews.
 
 ## 📈 Marketing & Growth Resources


### PR DESCRIPTION
Adds one factual entry to the existing **Product & Startup Directories** section.

Mydentify is a live product directory with permanent profiles, free product submissions, and weekly leaderboards. The entry links directly to the canonical homepage without tracking parameters.

Disclosure: this contribution comes from Mydentify founder Timothy Allard’s GitHub account.